### PR TITLE
fix: update theme in functional tests

### DIFF
--- a/tests/src/Functional/LoadTest.php
+++ b/tests/src/Functional/LoadTest.php
@@ -22,7 +22,7 @@ class LoadTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * A user with permission to administer site configuration.


### PR DESCRIPTION
# Description
This PR addresses a CI failure caused by using the deprecated `stable` theme in the Functional Test `LoadTest` by changing it to `stark`. ([Reference](https://www.drupal.org/node/3309392)). This fixes several [CI failures](https://github.com/digitalutsc/islandora_object_thumbnail/actions/runs/23595044834).